### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    # @items = Item.all
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,12 +125,12 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+      <% @items.each do |item| %>
+       <li class='list'>
+         <%= link_to "#" do %>
+         <div class='item-img-content'>
+          <%= image_tag item.image, class: "item-img"  if item.image.attached?%>
+       <% end %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +141,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,11 +153,10 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
+      
+      <% if @items.empty?%>
+        <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
@@ -173,9 +172,9 @@
           </div>
         </div>
         <% end %>
-      </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+       </li>
+      <% end %>
+
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
# What
 
画像の表示
出品した商品の一覧表示
上から、出品された日時が新しい順に表示されること
「画像/価格/商品名」の3つの情報について表示できていること
売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること

# Why

商品一覧表示機能のため

https://gyazo.com/799c42f301c23afdc6cb78e9f06891e5
https://gyazo.com/69cccc562de5c310d3d1fcc131a3a8a3
https://gyazo.com/b37edbd99a3ede1ffc88c4ac9f95429b
https://gyazo.com/1486ea520b5dcf5354a0681e32fd4ef8

ご確認どうぞよろしくお願いいたします。